### PR TITLE
fix(yarn): intentionally fail yarn install if the yarn.lock is not UTD

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: install deps
-        run: yarn
+        run: yarn install --frozen-lockfile
 
       - run: yarn lint
       - run: yarn prettier


### PR DESCRIPTION
See details 
https://github.com/LokaHQ/aws-cdk-template/pull/71 
